### PR TITLE
fs cleanup

### DIFF
--- a/serverapp/ParsePost.js
+++ b/serverapp/ParsePost.js
@@ -99,7 +99,7 @@ ParsePosts.prototype.setup = function () {
 
       // read the metadata and markdown associated with each post
       function buildData (postDateText, postSlug, postMarkdown) {
-        fs.readFile('blog/' + postDateText + '-' + postSlug + '.md', 'utf8', function(err, data){
+        fs.readFile(root + '/' + postDateText + '-' + postSlug + '.md', 'utf8', function(err, data){
           logger.debug('reading file: blog/' + postDateText + '-' + postSlug + '.md');
 
           var postData = loadMetadata(data);


### PR DESCRIPTION
- need the sync method (`fs.stat` vs. `fs.statSync`)
- post root shouldn't be hard-coded (`'blog/'` vs. `root + '/'`)
