### PR TITLE
make ParsePost respect config.postDir

### DIFF
--- a/serverapp/ParsePost.js
+++ b/serverapp/ParsePost.js
@@ -99,7 +99,7 @@ ParsePosts.prototype.setup = function () {
 
       // read the metadata and markdown associated with each post
       function buildData (postDateText, postSlug, postMarkdown) {
-        fs.readFile('blog/' + postDateText + '-' + postSlug + '.md', 'utf8', function(err, data){
+        fs.readFile(config.postDir + '/' + postDateText + '-' + postSlug + '.md', 'utf8', function(err, data){
           logger.debug('reading file: blog/' + postDateText + '-' + postSlug + '.md');
 
           var postData = loadMetadata(data);


### PR DESCRIPTION
Previously the blog directory was hardcoded, now it's being respected when loading files.
