### PR TITLE
redo parsing to be less aggressive, swap yaml to yamljs

### DIFF
--- a/blog/2013-06-02-just-a-person.md
+++ b/blog/2013-06-02-just-a-person.md
@@ -1,9 +1,11 @@
-#date: 2013-06-02 22:04:39 GMT
-#slug: just-a-person
-#tumblr_post_url: http://adambrault.com/post/52004360603/just-a-person
-#tags: 
-#title: just a person
-#type: text
+---
+date: 2013-06-02 22:04:39 GMT
+slug: just-a-person
+tumblr_post_url: http://adambrault.com/post/52004360603/just-a-person
+tags: 
+title: just a person
+type: text
+---
 
 At the conclusion of this year's JSConf, Chris Williams held an open discussion, taking questions and comments from the several hundred gathered.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bucker": "~0.4.0",
     "gravatar": "~1.0.6",
     "wtchr": "0.0.1",
-    "yaml": "0.2.3"
+    "yamljs": "~0.1.4"
   },
   "main": "server.js"
 }


### PR DESCRIPTION
so the yaml package apparently is really picky, so i swapped it out for yamljs which works more consistently.

also i dropped the regex matching for a simple line-by-line loop to avoid the crazy errors in parsing.

sample post in the repo was updated to reflect how metadata should look.
