### PR TITLE
Don't crash on non-date filenames

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,14 +1,3 @@
-.DS_Store
-node_modules
-lib-cov
-*.seed
-*.log
-*.csv
-*.dat
-*.out
-*.pid
-*.gz
-pids
-logs
-results
-npm-debug.log
+example
+Makefile
+test

--- a/lib/bumble.js
+++ b/lib/bumble.js
@@ -1,8 +1,19 @@
 var Handlers = require('./bumble/handlers');
+var _ = require('underscore');
+var defaults = {
+    rssUrl: '/rss',
+    postDir: 'blog',
+    blogHome: '/',
+    maxPosts: 10
+
+};
 
 exports.register = function (plugin, config, next) {
-    var home = config.blogHome;
-    var handlers = new Handlers(config, function _handlersLoaded() {
+    var handlers, home;
+    _.defaults(config, defaults);
+    home = config.blogHome;
+    config.log = plugin.log;
+    handlers = new Handlers(config, function _handlersLoaded() {
         plugin.bind(handlers);
         plugin.route({
             method: 'get',

--- a/lib/bumble/ParsePosts.js
+++ b/lib/bumble/ParsePosts.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter;
-var logger = require('bucker').createLogger();
 var walk = require('walk');
 var fs = require('fs');
 var wtchr = require('wtchr');
@@ -10,7 +9,6 @@ var gravatar = require('gravatar');
 var util = require('util');
 var dateFormat = /(\d{4})\-((0|1)\d)\-((0|1|2|3)\d)-/;
 var posts = [];
-var postDate, postSlug, postDateText;
 
 require('sugar');
 
@@ -25,38 +23,48 @@ function ParsePosts() {
 
 util.inherits(ParsePosts, EventEmitter);
 
-ParsePosts.prototype.parseFile = function (config, file, callback) {
 
-    var postDir = require('path').dirname(require.main.filename) + '/' + config.postDir;
+ParsePosts.prototype.parseFile = function (file, done) {
+    var self = this;
+    var postDir = require('path').dirname(require.main.filename) + '/' + self.config.postDir;
 
-    // set the slug to the filename
-    postSlug = file.name.remove(dateFormat).remove('.md');
-    // var postSlug = 'readme';
-    //logger.debug('02 postSlug: ' + postSlug);
+    // read the metadata and markdown associated with this post
+    fs.readFile(postDir + '/' + file.name, 'utf8', function (err, data) {
+        var postSlug, postData;
+        if (err) {
+            self.config.log(['error', 'bumble'], 'Error reading post `' + file.name + '`, skipping ' + err.stack);
+            // skip this file
+            return done();
+        }
 
-    // does it start with the proper date format? (YYYY-MM-DD)
-    if (file.name.startsWith(dateFormat)) {
-        postDateText = file.name.first(10);
-        postDate = Date.create(postDateText);
-        //logger.debug('03 postDate: ' + postDate + ' (from filename)');
-        buildData(config, postDateText, postSlug);
-    }
+        postSlug = file.name.remove(dateFormat).remove('.md'); // set the slug to the filename minus optional dateFormat
 
-    else {
-        // get the date from the file created timestamp
-        postDate = Date.create(fs.statSync(postDir + '/' + file.name).ctime);
-        //logger.debug('03 postDate: ' + postDate + ' (from timestamp)');
-    }
+        // add the metadata to the post array
+        postData = parsePostData(data, file.name);
 
-    // helper function to check for and load metadata
-    // if the first line of the file does not start with # we return an
+        postData.formattedDate = Date.create(postData.date).format('{Mon} {dd}, {yyyy}');
+        postData.fullSlug = Date.create(postData.date).format('{yyyy}-{MM}-{dd}') + '-' + postSlug;
+        postData.url = self.config.blogHome + Date.create(postData.date).format('{yyyy}/{MM}/{dd}/') + postSlug;
+        postData.permalink = self.config.siteUrl + postData.url;
+        postData.date = Date.create(postData.date);
+
+        posts.push(postData);
+
+        // go to the next file
+        done();
+    });
+
+    // If the first line of the file does not start with --- we return an
     // empty hash, otherwise we parse until we find a line that does not start with #
     // metadata should be saved in the form
-    // # key: value
-    function loadMetadata(config, file) {
-        var metadata = {};
+    // ---
+    // (yaml data)
+    // ---
+    // yaml data will then be parsed
+    function parsePostData(file) {
+        var postData = {};
         var post = [];
-        var front_matter = [];
+        var metadata = [];
 
         var in_metadata = false;
         var done = false;
@@ -72,7 +80,7 @@ ParsePosts.prototype.parseFile = function (config, file, callback) {
                 }
             } else if (in_metadata) {
                 if (!line.match(/^---/)) {
-                    front_matter.push(line);
+                    metadata.push(line);
                 } else {
                     in_metadata = false;
                     done = true;
@@ -80,52 +88,25 @@ ParsePosts.prototype.parseFile = function (config, file, callback) {
             }
         });
 
-        front_matter = front_matter.join('\n');
+        metadata = metadata.join('\n');
         post = post.join('\n');
 
-        metadata = yaml.load(front_matter);
+        postData = yaml.load(metadata);
 
-        return _.extend({}, metadata, {
+        return _.defaults(postData, {
             postBody: marked(post),
-            title: metadata.title,
-            date: Date.create(metadata.date),
-            slug: metadata.slug,
-            blogTitle: config.blogTitle,
-            blogSubtitle: config.blogSubtitle,
-            author: metadata.author || config.blogAuthor,
-            blogAuthor: config.blogAuthor,
-            blogAuthorEmail: config.blogAuthorEmail,
-            blogBio: config.blogBio,
-            siteUrl: config.siteUrl,
-            rssUrl: config.rssUrl,
-            gravatar: gravatar.url(config.blogAuthorEmail, 100),
-            maxPosts: config.maxPosts
+            author: self.config.blogAuthor,
+            blogTitle: self.config.blogTitle,
+            blogSubtitle: self.config.blogSubtitle,
+            blogAuthor: self.config.blogAuthor,
+            blogAuthorEmail: self.config.blogAuthorEmail,
+            blogBio: self.config.blogBio,
+            siteUrl: self.config.siteUrl,
+            rssUrl: self.config.rssUrl,
+            gravatar: gravatar.url(self.config.blogAuthorEmail, 100),
+            maxPosts: self.config.maxPosts
         });
     }
-
-    // read the metadata and markdown associated with each post
-    function buildData(config, postDateText, postSlug) {
-        var postDir = require('path').dirname(require.main.filename) + '/' + config.postDir;
-
-        fs.readFile(postDir + '/' + file.name, 'utf8', function (err, data) {
-            //logger.debug('reading file: blog/' + postDateText + '-' + postSlug + '.md');
-
-            var postData = loadMetadata(config, data, file.name);
-            postData.formattedDate = Date.create(postData.date).format('{Mon} {dd}, {yyyy}');
-            postData.fullSlug = Date.create(postData.date).format('{yyyy}-{MM}-{dd}') + '-' + postSlug;
-            postData.url = config.blogHome + Date.create(postData.date).format('{yyyy}/{MM}/{dd}/') + postSlug;
-            postData.permalink = config.siteUrl + postData.url;
-
-            // add the metadata to the post array
-            //logger.debug(require('util').inspect(postData, false, null, true));
-            posts.push(postData);
-
-            // go to the next file
-            callback();
-        });
-    }
-
-    //logger.info(util.inspect(posts));
 };
 
 ParsePosts.prototype.setup = function (config) {
@@ -136,11 +117,12 @@ ParsePosts.prototype.setup = function (config) {
 
     var walker = walk.walk(postDir);
 
+    self.config = config;
+
     walker.on("file", function (root, file, next) {
-        // logger.info('walking files');
         // does the file have a .md extension?
         if (file.name.endsWith('.md')) {
-            self.parseFile(config, file, next);
+            self.parseFile(file, next);
         }
         else {
             next();
@@ -149,43 +131,40 @@ ParsePosts.prototype.setup = function (config) {
 
     walker.on("end", function () {
 
-        // logger.info(util.inspect(posts));
-
         self.emit('ready', posts, config);
-        // logger.info('walked, loaded and ready');
 
         var watcher = wtchr(postDir);
 
         watcher.on('create', function (filename) {
             if (!filename.match(/\.md$/)) return;
             var file = filename.replace(postDir + '/', '');
-            logger.debug('adding new file:', file);
-            self.parseFile(config, { name: file }, function () {
+            self.config.log(['debug', 'bumble'], 'adding new file: ' + file);
+            self.parseFile({ name: file }, function () {
                 self.emit('update', posts);
-                logger.info('watcher found a new file');
+                self.config.log(['info', 'bumble'], 'watcher found a new file');
             });
         });
 
         watcher.on('change', function (filename) {
             if (!filename.match(/\.md$/)) return;
             var file = filename.replace(postDir + '/', '');
-            logger.debug('changing file:', file);
+            self.config.log(['debug', 'bumble'], 'changing file: ' + file);
             var postIndex = posts.indexOf(_.findWhere(posts, { fullSlug: file.replace(/\.md$/, '') }));
             posts.splice(postIndex, 1);
-            self.parseFile(config, { name: file }, function () {
+            self.parseFile({ name: file }, function () {
                 self.emit('update', posts);
-                logger.info('watcher found an updated file');
+                self.config.log(['info', 'bumble'], 'watcher found an updated file');
             });
         });
 
         watcher.on('delete', function (filename) {
             if (!filename.match(/\.md$/)) return;
             var file = filename.replace(postDir + '/', '');
-            logger.debug('deleting file: %s', file);
+            self.config.log(['debug', 'bumble'], 'deleting file: ' + file);
             var postIndex = posts.indexOf(_.findWhere(posts, { fullSlug: file.replace(/\.md$/, '') }));
             posts.splice(postIndex, 1);
             self.emit('update', posts);
-            logger.info('watcher found a deleted file');
+            self.config.log(['info', 'bumble'], 'watcher found a deleted file');
         });
 
     });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "bugs": "https://github.com/adambrault/bumble/issues",
   "dependencies": {
-    "bucker": "^1.0.9",
     "gravatar": "~1.0.6",
     "js-yaml": "^3.0.2",
     "jsonfile": "~1.1.1",
@@ -19,6 +18,7 @@
     "wtchr": "0.0.1"
   },
   "devDependencies": {
+    "bucker": "^1.0.9",
     "hapi": "^3.0.0",
     "lab": "^1.9.0",
     "precommit-hook": "^0.3.10",


### PR DESCRIPTION
Currently if you put a file in hour posts directory that doesn't have a date part in the name, bumble crashes.  This PR fixes that.

This also closes #21 and #22
