### PR TITLE
Don't clobber blogContext when viewing a post.

### DIFF
--- a/lib/bumble/views.js
+++ b/lib/bumble/views.js
@@ -120,11 +120,11 @@ Views.prototype.blogPost = function (year, month, day, slug, next) {
     //lastTag: thisPost.lastTag,
 
     if (thisPost) {
-        context = _.extend({}, this.blogContext, {
+        context = _.extend({
             bodyId: 'post',
             pageTitle: thisPost.title,
             postData: thisPost
-        });
+        }, this.blogContext);
     }
     return next(false, context);
 };


### PR DESCRIPTION
This had the funny side effect of changing the blog homepage's title to the title of the most recently viewed blog post.
